### PR TITLE
Fix: Replace variable-length array with std::vector for standard compliance

### DIFF
--- a/src/model_parser/helper.hpp
+++ b/src/model_parser/helper.hpp
@@ -39,7 +39,7 @@ namespace get
     vector<int> DependentNodes(onnx::GraphProto& graph, const string& nodeInput);
     vector<vector<int>> AdjacencyMatrix(onnx::GraphProto& graph);
     vector<int> TopologicallySortedNodes(onnx::GraphProto& graph);
-    void dfs(int node, int visited[], const vector<vector<int>>& adj, stack<int>& st);
+    void dfs(int node, vector<int> &visited, const vector<vector<int>>& adj, stack<int>& st);
 
     /**
      * @brief Retrieve the initializer from the ONNX graph by its name.

--- a/src/model_parser/helper_impl.hpp
+++ b/src/model_parser/helper_impl.hpp
@@ -99,7 +99,8 @@ vector<int> get::TopologicallySortedNodes(onnx::GraphProto &graph)
     //     i++;
     // }
 
-    int visitedNode[totalNodes] = {0};
+    vector<int> visitedNode(totalNodes, 0);
+
     stack<int> st;
 
     for (int i = 0; i < totalNodes; i++)
@@ -118,7 +119,7 @@ vector<int> get::TopologicallySortedNodes(onnx::GraphProto &graph)
     return topologicalShort;
 }
 
-void get::dfs(int node, int visited[],
+void get::dfs(int node, vector<int>& visited,
               const vector<vector<int>> &adj, stack<int> &st)
 {
     visited[node] = 1;


### PR DESCRIPTION
- Replaced variable-length array `visitedNode[totalNodes]` with `std::vector` for standard C++ compliance.
- Ensures compatibility across different compilers, including MSVC, which does not support VLAs.
