### PR TITLE
Add basic CI infrastructure with GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ name: onnx-mlpack
 
 jobs:
   linux:
-    runner: ubuntu-latest
+    name: "Linux build"
+    if: ${{ github.repository == 'mlpack/onnx-mlpack' }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
@@ -53,7 +55,9 @@ jobs:
         print_output: true
 
   macos:
-    runner: macOS-latest
+    name: "macOS build"
+    if: ${{ github.repository == 'mlpack/onnx-mlpack' }}
+    runs-on: macOS-latest
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+# ci.yml: defines the CI jobs for the onnx-mlpack project.
+#
+# We simply build and run the tests on Linux and macOS.
+# For now, Windows isn't built due to ONNX packaging difficulties.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  release:
+    types: [published, created, edited]
+permissions:
+  contents: read
+name: onnx-mlpack
+
+jobs:
+  linux:
+    runner: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --allow-unauthenticated \
+            libopenblas-dev libstb-dev libonnx-dev libprotobuf-dev
+
+    - name: Configure onnx-mlpack with CMake
+      run: |
+        mkdir build && cd build
+        cmake ../
+
+    - name: Build onnx-mlpack
+      run: cd build && make -j4
+
+    - name: Run tests
+      run: cd build && ./onnx_mlpack_test -r junit -o onnx_mlpack_test.junit.xml
+
+    - name: Parse test output
+      uses: rcurtin/test-summary-action@dist
+      if: success() || failure()
+      with:
+        paths: "build/*.junit.xml"
+        show: "fail, skip"
+        fail_job: true
+        print_output: true
+
+  macos:
+    runner: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install build dependencies
+      run: |
+        sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+        brew install libomp openblas armadillo cereal ensmallen onnx protobuf
+
+    - name: Configure onnx-mlpack with CMake
+      run: |
+        mkdir build && cd build
+        cmake ../
+
+    - name: Build onnx-mlpack
+      run: cd build && make -j4
+
+    - name: Run tests
+      run: cd build && ./onnx_mlpack_test -r junit -o onnx_mlpack_test.junit.xml
+
+    - name: Parse test output
+      uses: rcurtin/test-summary-action@dist
+      if: success() || failure()
+      with:
+        paths: "build/*.junit.xml"
+        show: "fail, skip"
+        fail_job: true
+        print_output: true


### PR DESCRIPTION
This just adds a really simple Linux and macOS CI job: it checks out the code, builds the tests, and runs them.

This depends on #3 being merged (the diff will be ugly until that is merged).