### PR TITLE
Add names to subgraphs so we can print those instead of indices.

### DIFF
--- a/include/onnx_mlpack/matchers/celu.hpp
+++ b/include/onnx_mlpack/matchers/celu.hpp
@@ -14,6 +14,8 @@ class CELUSubgraph : public Subgraph
  public:
   CELUSubgraph() : Subgraph({ "Celu" }) { }
 
+  inline const char* Name() { return "CELU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/elu.hpp
+++ b/include/onnx_mlpack/matchers/elu.hpp
@@ -14,6 +14,8 @@ class ELUSubgraph : public Subgraph
  public:
   ELUSubgraph() : Subgraph({ "Elu" }) { }
 
+  inline const char* Name() { return "ELU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/gelu.hpp
+++ b/include/onnx_mlpack/matchers/gelu.hpp
@@ -14,6 +14,8 @@ class GELUSubgraph : public Subgraph
  public:
   GELUSubgraph() : Subgraph({ "Gelu" }) { }
 
+  inline const char* Name() { return "GELU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/gelu_exact.hpp
+++ b/include/onnx_mlpack/matchers/gelu_exact.hpp
@@ -14,6 +14,8 @@ class GELUExactSubgraph : public Subgraph
  public:
   GELUExactSubgraph() : Subgraph({ "Gelu" }) { }
 
+  inline const char* Name() { return "GELUExact"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/hard_sigmoid.hpp
+++ b/include/onnx_mlpack/matchers/hard_sigmoid.hpp
@@ -14,6 +14,8 @@ class HardSigmoidSubgraph : public Subgraph
  public:
   HardSigmoidSubgraph() : Subgraph({ "HardSigmoid" }) { }
 
+  inline const char* Name() { return "HardSigmoid"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/hard_swish.hpp
+++ b/include/onnx_mlpack/matchers/hard_swish.hpp
@@ -15,6 +15,8 @@ class HardSwishSubgraph : public Subgraph
  public:
   HardSwishSubgraph() : Subgraph({ "HardSwish" }) { }
 
+  inline const char* Name() { return "HardSwish"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/leaky_relu.hpp
+++ b/include/onnx_mlpack/matchers/leaky_relu.hpp
@@ -14,6 +14,8 @@ class LeakyReLUSubgraph : public Subgraph
  public:
   LeakyReLUSubgraph() : Subgraph({ "LeakyRelu" }) { }
 
+  inline const char* Name() { return "LeakyReLU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/linear_gemm.hpp
+++ b/include/onnx_mlpack/matchers/linear_gemm.hpp
@@ -15,6 +15,8 @@ class LinearGemmSubgraph : public Subgraph
  public:
   LinearGemmSubgraph() : Subgraph({ "Gemm" }) { }
 
+  inline const char* Name() { return "LinearGEMM"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/linear_matmul_add.hpp
+++ b/include/onnx_mlpack/matchers/linear_matmul_add.hpp
@@ -16,6 +16,8 @@ class LinearMatMulAddSubgraph : public Subgraph
   // Required structure: MatMul -> Add.
   LinearMatMulAddSubgraph() : Subgraph({ "MatMul", "Add" }, { { 0, 1 } }) { }
 
+  inline const char* Name() { return "LinearMatMulAdd"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/linear_no_bias_gemm.hpp
+++ b/include/onnx_mlpack/matchers/linear_no_bias_gemm.hpp
@@ -14,6 +14,8 @@ class LinearNoBiasGemmSubgraph : public Subgraph
  public:
   LinearNoBiasGemmSubgraph() : Subgraph({ "Gemm" }) { }
 
+  inline const char* Name() { return "LinearNoBiasGEMM"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/linear_no_bias_matmul.hpp
+++ b/include/onnx_mlpack/matchers/linear_no_bias_matmul.hpp
@@ -14,6 +14,8 @@ class LinearNoBiasMatMulSubgraph : public Subgraph
  public:
   LinearNoBiasMatMulSubgraph() : Subgraph({ "MatMul" }) { }
 
+  inline const char* Name() { return "LinearNoBiasMatMul"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/matcher_impl.hpp
+++ b/include/onnx_mlpack/matchers/matcher_impl.hpp
@@ -182,8 +182,9 @@ inline Matching Matcher(const onnx::GraphProto& graph,
       if (subMatchings.size() > 0)
       {
         // TODO: get name of actual subgraph.
-        std::cout << "  Subgraph " << s << " matched to " << subMatchings.size()
-            << " candidates:" << std::endl;
+        std::cout << "  Subgraph " << s << " (" << subgraphs[s]->Name()
+            << ") matched to " << subMatchings.size() << " candidates:"
+            << std::endl;
         for (size_t k = 0; k < subMatchings.size(); ++k)
         {
           const Matching& m = subMatchings[k];

--- a/include/onnx_mlpack/matchers/mish.hpp
+++ b/include/onnx_mlpack/matchers/mish.hpp
@@ -14,6 +14,8 @@ class MishSubgraph : public Subgraph
  public:
   MishSubgraph() : Subgraph({ "Mish" }) { }
 
+  inline const char* Name() { return "Mish"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/mish_multi_op.hpp
+++ b/include/onnx_mlpack/matchers/mish_multi_op.hpp
@@ -16,6 +16,8 @@ class MishMultiOpSubgraph : public Subgraph
   MishMultiOpSubgraph() : Subgraph(
       { "Softplus", "Tanh", "Mul" }, { { 0, 1 }, { 1, 2 } } ) { }
 
+  inline const char* Name() { return "MishMultiOp"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/prelu.hpp
+++ b/include/onnx_mlpack/matchers/prelu.hpp
@@ -14,6 +14,8 @@ class PReLUSubgraph : public Subgraph
  public:
   PReLUSubgraph() : Subgraph({ "PRelu" }) { }
 
+  inline const char* Name() { return "PReLU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/relu.hpp
+++ b/include/onnx_mlpack/matchers/relu.hpp
@@ -14,6 +14,8 @@ class ReLUSubgraph : public Subgraph
  public:
   ReLUSubgraph() : Subgraph({ "Relu" }) { }
 
+  inline const char* Name() { return "ReLU"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/selu.hpp
+++ b/include/onnx_mlpack/matchers/selu.hpp
@@ -14,6 +14,8 @@ class SELUSubgraph : public Subgraph
  public:
   SELUSubgraph() : Subgraph({ "Selu" }) { }
 
+  inline const char* Name() { return "Selu"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/sigmoid.hpp
+++ b/include/onnx_mlpack/matchers/sigmoid.hpp
@@ -14,6 +14,8 @@ class SigmoidSubgraph : public Subgraph
  public:
   SigmoidSubgraph() : Subgraph({ "Sigmoid" }) { }
 
+  inline const char* Name() { return "Sigmoid"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/softplus.hpp
+++ b/include/onnx_mlpack/matchers/softplus.hpp
@@ -14,6 +14,8 @@ class SoftplusSubgraph : public Subgraph
  public:
   SoftplusSubgraph() : Subgraph({ "Softplus" }) { }
 
+  inline const char* Name() { return "Softplus"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/softplus_threshold.hpp
+++ b/include/onnx_mlpack/matchers/softplus_threshold.hpp
@@ -16,6 +16,8 @@ class SoftplusThresholdSubgraph : public Subgraph
   SoftplusThresholdSubgraph() : Subgraph(
       { "Softplus", "Greater", "Where" }, { { 0, 2 }, { 1, 2 } } ) { }
 
+  inline const char* Name() { return "SoftplusThreshold"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/subgraph.hpp
+++ b/include/onnx_mlpack/matchers/subgraph.hpp
@@ -60,6 +60,9 @@ class Subgraph
 
   virtual ~Subgraph() { }
 
+  // The name of the subgraph, for printing debug output.
+  virtual inline const char* Name() = 0;
+
   const size_t NumVertices() const { return vertices.size(); }
   const size_t NumEdges() const { return edges.size(); }
   const size_t NumInputs() const { return numInputs; }

--- a/include/onnx_mlpack/matchers/swish.hpp
+++ b/include/onnx_mlpack/matchers/swish.hpp
@@ -14,6 +14,8 @@ class SwishSubgraph : public Subgraph
  public:
   SwishSubgraph() : Subgraph({ "Swish" }) { }
 
+  inline const char* Name() { return "Swish"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 

--- a/include/onnx_mlpack/matchers/tanh.hpp
+++ b/include/onnx_mlpack/matchers/tanh.hpp
@@ -14,6 +14,8 @@ class TanhSubgraph : public Subgraph
  public:
   TanhSubgraph() : Subgraph({ "Tanh" }) { }
 
+  inline const char* Name() { return "Tanh"; }
+
   inline bool Validate(const arma::uvec& indices,
                        const onnx::GraphProto& graph) const override;
 


### PR DESCRIPTION
This is just a minor cleanup for output.  Before (a snippet of output from a test):

```
  Subgraph 4 matched to 1 candidates:
   - 0: { 1 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 5 matched to 1 candidates:
   - 0: { 3 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 6 matched to 1 candidates:
   - 0: { 5 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 7 matched to 1 candidates:
   - 0: { 7 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
```

After:

```
  Subgraph 4 (CELU) matched to 1 candidates:
   - 0: { 1 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 5 (ELU) matched to 1 candidates:
   - 0: { 3 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 6 (GELUExact) matched to 1 candidates:
   - 0: { 5 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
  Subgraph 7 (GELU) matched to 1 candidates:
   - 0: { 7 }
   * Subgraph match 0 can be coalesced with candidate matching 0.
```